### PR TITLE
Ajout des données Maximilien (Atexo)

### DIFF
--- a/scripts/sources/atexo-maximilien/convert.sh
+++ b/scripts/sources/atexo-maximilien/convert.sh
@@ -1,8 +1,6 @@
-
 #!/bin/bash
 
-# Ce script convertit les données de l'AIFE en DECP JSON
 
 source=$1
 
-$DECP_HOME/scripts/sources/data.gouv.fr_aife/convert.sh $source
+$DECP_HOME/scripts/sources/shared/convert-xml.sh $source

--- a/scripts/sources/atexo-maximilien/convert.sh
+++ b/scripts/sources/atexo-maximilien/convert.sh
@@ -1,0 +1,8 @@
+
+#!/bin/bash
+
+# Ce script convertit les données de l'AIFE en DECP JSON
+
+source=$1
+
+$DECP_HOME/scripts/sources/data.gouv.fr_aife/convert.sh $source

--- a/scripts/sources/atexo-maximilien/get.sh
+++ b/scripts/sources/atexo-maximilien/get.sh
@@ -1,0 +1,17 @@
+
+#!/bin/bash
+
+# Récupération des données essentielles publiées sur la plateforme Atexo Maximilien
+
+# À partir du répertoire racine (où se trouve README.md), création d'un repértoire temporaire
+
+# Récupération des données, tous les fichiers sont stockés dans le même dossier
+# Le nombre de fichiers sur cette source pouvant un jour atteindre des sommets, cette solution n'est pas pérenne
+
+# Récupération de la liste des ressources à partir de l'adresse des jeux de données.
+
+source=$1
+
+curl -L "https://www.data.gouv.fr/fr/datasets/r/350042f4-3fda-4233-940e-f21ab9e081ac" > $source.xml
+
+

--- a/scripts/sources/data.gouv.fr_aife/convert.sh
+++ b/scripts/sources/data.gouv.fr_aife/convert.sh
@@ -1,18 +1,6 @@
 #!/bin/bash
 
-# Ce script convertit les données de l'AIFE en DECP JSON
 
 source=$1
 
-cd $DECP_HOME/sources/$source
-
-mkdir -p $DECP_HOME/json/$source
-
-for xml in `ls *.*`
-do
-  echo "$xml..."
-  #Converti le XML DECP vers JSON DECP
-  $DECP_HOME/scripts/xmlDECP2jsonDECP.sh $xml >  $DECP_HOME/json/$source/$xml.json
-done
-
-cd $DECP_HOME/json/$source
+$DECP_HOME/scripts/sources/shared/convert-xml.sh $source

--- a/scripts/sources/grandlyon/convert.sh
+++ b/scripts/sources/grandlyon/convert.sh
@@ -1,18 +1,6 @@
 #!/bin/bash
 
-# Ce script convertit les données du Grand Lyon en DECP JSON
 
 source=$1
 
-cd $DECP_HOME/sources/$source
-
-mkdir -p $DECP_HOME/json/$source
-
-for xml in *.xml
-do
-    
-#Converti le XML DECP vers JSON DECP
-$DECP_HOME/scripts/xmlDECP2jsonDECP.sh $xml >  $DECP_HOME/json/$source/$xml.json
-done
-
-cd $DECP_HOME/json/$source
+$DECP_HOME/scripts/sources/shared/convert-xml.sh $source

--- a/scripts/sources/shared/convert-xml.sh
+++ b/scripts/sources/shared/convert-xml.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+source=$1
+
+cd $DECP_HOME/sources/$source
+
+mkdir -p $DECP_HOME/json/$source
+
+for xml in `ls *.*`
+do
+  echo "$xml..."
+  #Converti le XML DECP vers JSON DECP
+  $DECP_HOME/scripts/xmlDECP2jsonDECP.sh $xml >  $DECP_HOME/json/$source/$xml.json
+done
+
+cd $DECP_HOME/json/$source

--- a/sources/metadata.json
+++ b/sources/metadata.json
@@ -28,5 +28,11 @@
     "code": "grandlyon",
     "description": "Marchés du Grand Lyon publiés sur data.grandlyon.com",
     "url": "https://download.data.grandlyon.com/files/grandlyon/citoyennete/marches_publics.xml"
+  },
+  {
+    "id": "6",
+    "code": "atexo-maximilien",
+    "description": "DECP télécharger depuis les plateformes Atexo",
+    "url": "https://www.data.gouv.fr/datasets/5f4d1921f7e627ef3ae26944"
   }
 ]


### PR DESCRIPTION
Cette PR ajoute une nouvelle source de données : les DECP scrapées de façon hebdomadaire sur marches.maximilien.fr avec l'accord de la plateforme ([dataset](https://www.data.gouv.fr/datasets/5f4d1921f7e627ef3ae26944)).

À ce jour, ces données contiennent 3252 marchés provenant de 139 acheteurs franciliens.