### PR TITLE
Nettoyage des données contenant des balises <![CDATA[]]>.

### DIFF
--- a/scripts/xmlDECP2jsonDECP.sh
+++ b/scripts/xmlDECP2jsonDECP.sh
@@ -2,4 +2,4 @@
 
 # Ce script convertit les données en DECP JSON
 
-xml2json $1 | jq -f $DECP_HOME/scripts/jq/jsonDECP.jq
+xmllint --format $1 | sed 's/<!\[CDATA\[\([^]]*\)\]\]>/\1/g' | xml2json | jq -f $DECP_HOME/scripts/jq/jsonDECP.jq


### PR DESCRIPTION
Actuellement certains fichiers possède des balises <![CDATA[]]>.

Ces balises ne sont pas correctement gérées par les outils utilisés ensuite dans ce projet.

Pour régler le souci, il est nécessaire de faire disparaître ces balises tout en conservant les données présentes dans ces balises.

Ainsi <![CDATA[ma donnée que je dois conserver]]> devient ma donnée que je dois conserver