### PR TITLE
Stockage dans un dossier de certain fichier pour pouvoir les mettre en cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
         steps:
             - checkout
             - run: date +%F > date
+            - run: export DATE=$(cat date) >> $BASH_ENV
             - restore_cache:
                 keys:
                   - data-in-{{ .Branch }}-{{ checksum "sources/metadata.json" }}-{{ checksum "date" }}
@@ -34,13 +35,16 @@ jobs:
                      ./process.sh all fix only
                      ./process.sh all convert only
                      ./process.sh all package only
+                     ./process.sh all package nothing # traitement final pour regrouper toutes les données
             - save_cache:
                 key: data-out-{{ .Branch }}-{{ checksum "date" }}
                 paths:
+                  # - "results/decp_previous.json"
                   - "json/decp.json"
                   - "xml/decp.xml"
-                  - "decp_*.json"
-                  - "decp_*.xml"
+                  - "results/"
+                  # - "decp_*.json"
+                  # - "decp_*.xml"
                   - "json/decp.ocds.json"
     publish:
       docker:
@@ -76,6 +80,13 @@ workflows:
           #     requires:
           #       - hold # Will only be validated if approved so get_data won't run until then
           - process
+          - hold: # <<< A job that will require manual approval in the CircleCI web application.
+              type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
+          - publish:
+              context:
+                - decp-rama-context
+              requires:
+                - hold
 
     daily:
       jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,6 @@ jobs:
         steps:
             - checkout
             - run: date +%F > date
-            - run: export DATE=$(cat date) >> $BASH_ENV
             - restore_cache:
                 keys:
                   - data-in-{{ .Branch }}-{{ checksum "sources/metadata.json" }}-{{ checksum "date" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,13 +79,13 @@ workflows:
           #     requires:
           #       - hold # Will only be validated if approved so get_data won't run until then
           - process
-          - hold: # <<< A job that will require manual approval in the CircleCI web application.
-              type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
-          - publish:
-              context:
-                - decp-rama-context
-              requires:
-                - hold
+          # - hold: # <<< A job that will require manual approval in the CircleCI web application.
+          #     type: approval # <<< This key-value pair will set your workflow to a status of "On Hold"
+          # - publish:
+          #     context:
+          #       - decp-rama-context
+          #     requires:
+          #       - hold
 
     daily:
       jobs:

--- a/process.sh
+++ b/process.sh
@@ -91,7 +91,7 @@ case $source in
           echo ""
           echo "## Conversion du JSON du jour en XML..."
           scripts/jsonDECP2xmlDECP.sh results/decp_$date.json > results/decp_$date.xml
-          ls -lh decp_$date.xml
+          ls -lh results/decp_$date.xml
 
           echo ""
           echo "## Conversion du JSON agrégé au format OCDS JSON..."

--- a/process.sh
+++ b/process.sh
@@ -27,76 +27,76 @@ case $source in
         echo "Sources :"
         echo $sources
         echo ""
-        if [[ "$mode" != "nothing" ]]
-        then
           ## Pas de traitement des sources si l'option "nothing" est fourni
-          for source in $sources
-          do
-              ./process.sh $source $step $mode
-          done
-        fi
+        for source in $sources
+        do
+            ./process.sh $source $step $mode
+        done
 
-        echo ""
-        echo "## Fusion de tous les fichiers JSON de source en un seul"
-
-        scripts/mergeAllSources.sh
-
-        echo "## Exclusions des marchés avec anomalie"
-
-        scripts/excludeMarches.sh
-
-        echo ""
-        echo "## Correction des anomalie globales"
-
-        scripts/fixAll.sh
-
-        echo "## Génération des statistiques"
-
-        scripts/stats.sh
-
-        echo ""
-        echo "Extraction des marchés du jour"
-
-        case ${CIRCLE_BRANCH} in
-            *)
-
-            resource="https://www.data.gouv.fr/fr/datasets/r/16962018-5c31-4296-9454-5998585496d2"
-
-            ;;
-
-            # *)
-            # export api="https://next.data.gouv.fr/api/1"
-            # export resource_id_json="a53049f9-3536-4dab-b0fb-8928917cb12a"
-            # api_key=$NEXT_API_KEY
-            # ;;
-        esac
-
-        wget $resource -O decp_previous.json
-
-        # Le fichier des marchés du jour est sauvegardé dans ./decp_{date-iso}.json
-        scripts/get_new_data.sh decp_previous.json json/decp.json
-
-
-
-        if [[ ! -d xml  ]]
+        if [[ "$mode" == "nothing" ]]
         then
-            mkdir xml
+          echo ""
+          echo "## Fusion de tous les fichiers JSON de source en un seul"
+
+          scripts/mergeAllSources.sh
+
+          echo "## Exclusions des marchés avec anomalie"
+
+          scripts/excludeMarches.sh
+
+          echo ""
+          echo "## Correction des anomalie globales"
+
+          scripts/fixAll.sh
+
+          echo "## Génération des statistiques"
+
+          scripts/stats.sh
+
+          echo ""
+          echo "Extraction des marchés du jour"
+
+          case ${CIRCLE_BRANCH} in
+              *)
+
+              resource="https://www.data.gouv.fr/fr/datasets/r/16962018-5c31-4296-9454-5998585496d2"
+
+              ;;
+
+              # *)
+              # export api="https://next.data.gouv.fr/api/1"
+              # export resource_id_json="a53049f9-3536-4dab-b0fb-8928917cb12a"
+              # api_key=$NEXT_API_KEY
+              # ;;
+          esac
+
+          wget $resource -O results/decp_previous.json
+
+          # Le fichier des marchés du jour est sauvegardé dans ./decp_{date-iso}.json
+          scripts/get_new_data.sh results/decp_previous.json json/decp.json
+
+
+
+          if [[ ! -d xml  ]]
+          then
+              mkdir xml
+          fi
+
+          date=`date "+%F"`
+          echo ""
+          echo "## Conversion du JSON agrégé en XML..."
+          scripts/jsonDECP2xmlDECP.sh json/decp.json > xml/decp.xml
+          ls -lh xml/decp.xml
+
+          echo ""
+          echo "## Conversion du JSON du jour en XML..."
+          scripts/jsonDECP2xmlDECP.sh results/decp_$date.json > results/decp_$date.xml
+          ls -lh decp_$date.xml
+
+          echo ""
+          echo "## Conversion du JSON agrégé au format OCDS JSON..."
+          scripts/makeOCDS.sh json/decp.json
         fi
-
-        date=`date "+%F"`
-        echo ""
-        echo "## Conversion du JSON agrégé en XML..."
-        scripts/jsonDECP2xmlDECP.sh json/decp.json > xml/decp.xml
-        ls -lh xml/decp.xml
-
-        echo ""
-        echo "## Conversion du JSON du jour en XML..."
-        scripts/jsonDECP2xmlDECP.sh decp_$date.json > decp_$date.xml
-        ls -lh decp_$date.xml
-
-        echo ""
-        echo "## Conversion du JSON agrégé au format OCDS JSON..."
-        scripts/makeOCDS.sh json/decp.json
     ;;
     *)
 
@@ -118,6 +118,9 @@ case $source in
                         break;
                     fi
                 done
+             ;;
+             nothing)
+              echo "On ne fait rien concernant les sources"
              ;;
              *)
              echo "Seules les valeurs 'only' et 'sequence' sont acceptées."

--- a/publish-decp.sh
+++ b/publish-decp.sh
@@ -65,7 +65,7 @@ case ${CIRCLE_BRANCH} in
 
         echo "Publication de decp_$date.${ext}..."
 
-        curl "$api/datasets/$dataset_id/upload/" -F "file=@decp_${date}.${ext}" -F "filename=decp_$date" -H "X-API-KEY: $api_key" > dailyResource.json
+        curl "$api/datasets/$dataset_id/upload/" -F "file=@results/decp_${date}.${ext}" -F "filename=decp_$date" -H "X-API-KEY: $api_key" > dailyResource.json
 
         idDailyResource=`jq -r '.id' dailyResource.json`
 
@@ -81,4 +81,3 @@ case ${CIRCLE_BRANCH} in
 
 ;;
 esac
-

--- a/scripts/get_new_data.sh
+++ b/scripts/get_new_data.sh
@@ -41,6 +41,7 @@ if [[ $nbNewMarches -lt 2000 ]]
 
 # Méthode classique si peu de nouveaux marchés
 then
+<<<<<<< Updated upstream
 
     echo '{"marches":[' > temp.json
 
@@ -77,6 +78,6 @@ echo "Nombre de marchés dans le fichier des nouveaux marchés :"
 jq '.marches | length' temp.json
 
 date=`date "+%F"`
-jq . temp.json > decp_$date.json
+jq . temp.json > results/decp_$date.json
 
 # rm oldMarchesNoDuplicates newMarchesNoDuplicates oldMarchesRaw newMarchesRaw todayMarches temp.json

--- a/scripts/get_new_data.sh
+++ b/scripts/get_new_data.sh
@@ -41,7 +41,6 @@ if [[ $nbNewMarches -lt 2000 ]]
 
 # Méthode classique si peu de nouveaux marchés
 then
-<<<<<<< Updated upstream
 
     echo '{"marches":[' > temp.json
 


### PR DESCRIPTION
CircleCI n'acceptant pas les regex dans la définition du cache, il est nécessaire de mettre les fichier `decp_${date +%F}...` dans un dossier afin de pouvoir les mettre en cache