### PR TITLE
Utilisation de l'uid pour de dataset de megalis

### DIFF
--- a/scripts/sources/megalis-bretagne/get.sh
+++ b/scripts/sources/megalis-bretagne/get.sh
@@ -20,7 +20,7 @@
 
 # Récupération de la liste des ressources à partir de l'adresse des jeux de données.
 
-for dataset in donnees-essentielles-des-marches-publics-de-megalis-bretagne
+for dataset in 5f4f4f8910f4b55843deae51
 
 # 5be9feed8b4c41367475f40d is Private
 

--- a/sources/metadata.json
+++ b/sources/metadata.json
@@ -45,6 +45,6 @@
     "id": "8",
     "code": "megalis-bretagne",
     "description": "Données publiées par le profil d'acheteur Megalis Bretagne",
-    "url": "https://www.data.gouv.fr/api/1/datasets/donnees-essentielles-des-marches-publics-de-megalis-bretagne/"
+    "url": "https://www.data.gouv.fr/fr/datasets/5f4f4f8910f4b55843deae51"
   }
 ]


### PR DESCRIPTION
Permet de modifier le titre du dataset de megalis sans impacter la récupération auto des ressources par l'outil decp-rama