### PR TITLE
Use latest jq develop version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,12 @@ RUN git clone https://github.com/OpenDataServices/flatten-tool.git
 # install jq manually because of performance issues in release 1.6
 RUN mkdir jq
 RUN git clone https://github.com/stedolan/jq.git jq/repo
-RUN cd jq/repo && git checkout a9f97e9e61a910a374a5d768244e8ad63f407d3e && git submodule update --init \
+RUN cd /deps/jq/repo && git checkout a9f97e9e61a910a374a5d768244e8ad63f407d3e && git submodule update --init \
   && autoreconf -fi && ./configure --with-oniguruma=builtin --disable-maintainer-mode --prefix=$PWD/.. \
   && make && make install
-
 RUN chmod +x jq
-RUN cd xml2json && make
+
+RUN cd /deps/xml2json && make
 RUN cd /deps/flatten-tool
 RUN python3 -m venv .ve
 #RUN source .ve/bin/activate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 FROM python:3.9-slim
 RUN apt-get update && apt-get upgrade -y --no-install-recommends \
-  && apt-get install -y xsltproc libxml2-utils git build-essential curl zip unzip wget python3-venv python3-pip lftp --no-install-recommends \
+  && apt-get install -y xsltproc libxml2-utils git build-essential curl zip unzip wget python3-venv python3-pip lftp autoconf automake make libtool flex --no-install-recommends \
   && apt-get clean && rm -rf /var/cache/apt
 WORKDIR /deps
 #RUN git clone https://github.com/edsu/json2xml.git
 RUN git clone https://github.com/Cheedoong/xml2json.git
 RUN git clone https://github.com/OpenDataServices/flatten-tool.git
-RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O jq
+
+# install jq manually because of performance issues in release 1.6
+RUN mkdir jq
+RUN git clone https://github.com/stedolan/jq.git jq/repo
+RUN cd jq/repo && git checkout a9f97e9e61a910a374a5d768244e8ad63f407d3e && git submodule update --init \
+  && autoreconf -fi && ./configure --with-oniguruma=builtin --disable-maintainer-mode --prefix=$PWD/.. \
+  && make && make install
+
 RUN chmod +x jq
 RUN cd xml2json && make
 RUN cd /deps/flatten-tool
@@ -15,4 +22,4 @@ RUN python3 -m venv .ve
 RUN ["/bin/bash", "-c", "source .ve/bin/activate"]
 RUN pip install json2xml
 #RUN pip3 install -r requirements.txt
-ENV PATH="$PATH:/deps:/deps/xml2json"
+ENV PATH="$PATH:/deps:/deps/xml2json:/deps/jq/bin"


### PR DESCRIPTION
Bonjour,
Suite au build CI qui bloque semble t il à cause d'un timeout (1h ?), je tente d'apporter ma pierre : 

Changement du docker pour utiliser la dernière version depuis github.
Je me suis inspiré de ce script : https://gist.github.com/afrachioni/2c297903ce2de301b1e481dad2cfdbf9

Adapté en figeant le build sur le dernier hash du commit afin d'éviter d'avoir des versions de jq différentes dans la nature.

Je n'ai pas vérifié l'intégralité des cas d'utilisation de jq dans ce repo... Test effectué uniquement sur marches-publics.info : 

La section scripts prend environ 1 minute au total pour s'exécuter chez moi (Docker sur Win10, AMD, SSD).

```
root@65a1d9fd97a1:/decp# ./process.sh marches-publics.info fix only
============================================
2022-03-09T18:58:38 : début du traitement pour source marches-publics.info


Déplacement des fichiers téléchargés vers source/marches-publics.info/original-data...
Correction des anomalies
Correction de 2021-01-01.json...
Correction de 2021-01-02.json...
Correction de 2021-01-03.json...
Correction de 2021-01-04.json...
Correction de 2021-01-05.json...
Correction de 2021-01-06.json...
Correction de 2021-02-01.json...
Correction de 2021-02-02.json...
Correction de 2021-02-03.json...
Correction de 2021-02-04.json...
Correction de 2021-02-05.json...
Correction de 2021-03-01.json...
Correction de 2021-03-02.json...
Correction de 2021-03-03.json...
Correction de 2021-03-04.json...
Correction de 2021-03-05.json...
Correction de 2021-04-01.json...
Correction de 2021-04-02.json...
Correction de 2021-04-03.json...
Correction de 2021-04-04.json...
Correction de 2021-05-01.json...
Correction de 2021-05-02.json...
Correction de aws-marchespublics-annee-2018.json...
Correction de aws-marchespublics-annee-2019.json...
jq: error (at ./original-data/aws-marchespublics-annee-2019.json:3654667): Expected JSON value (while parsing '')
Correction de aws-marchespublics-annee-2020.json...
jq: error (at ./original-data/aws-marchespublics-annee-2020.json:4097946): Expected JSON value (while parsing '')
Correction de aws-marchespublics-annee-2021.json...
jq: error (at ./original-data/aws-marchespublics-annee-2021.json:3569669): Expected JSON value (while parsing '')
Correction de aws-marchespublics-annee-2022.json...
Copie des fichiers corrigés vers json/marches-publics.info...

2022-03-09T18:59:46 : fin du traitement pour source marches-publics.info
============================================

```
