### PR TITLE
Fix dureemois empty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
 FROM python:3.9-slim
 RUN apt-get update && apt-get upgrade -y --no-install-recommends \
-  && apt-get install -y xsltproc libxml2-utils git build-essential curl zip unzip wget python3-venv python3-pip lftp --no-install-recommends \
+  && apt-get install -y xsltproc libxml2-utils git build-essential curl zip unzip wget python3-venv python3-pip lftp autoconf automake make libtool flex --no-install-recommends \
   && apt-get clean && rm -rf /var/cache/apt
 WORKDIR /deps
 #RUN git clone https://github.com/edsu/json2xml.git
 RUN git clone https://github.com/Cheedoong/xml2json.git
 RUN git clone https://github.com/OpenDataServices/flatten-tool.git
-RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -O jq
+
+# install jq manually because of performance issues in release 1.6
+RUN mkdir jq
+RUN git clone https://github.com/stedolan/jq.git jq/repo
+RUN cd jq/repo && git checkout a9f97e9e61a910a374a5d768244e8ad63f407d3e && git submodule update --init \
+  && autoreconf -fi && ./configure --with-oniguruma=builtin --disable-maintainer-mode --prefix=$PWD/.. \
+  && make && make install
+
 RUN chmod +x jq
 RUN cd xml2json && make
 RUN cd /deps/flatten-tool
@@ -15,4 +22,4 @@ RUN python3 -m venv .ve
 RUN ["/bin/bash", "-c", "source .ve/bin/activate"]
 RUN pip install json2xml
 #RUN pip3 install -r requirements.txt
-ENV PATH="$PATH:/deps:/deps/xml2json"
+ENV PATH="$PATH:/deps:/deps/xml2json:/deps/jq/bin"

--- a/scripts/sources/marches-publics.info/fix.jq
+++ b/scripts/sources/marches-publics.info/fix.jq
@@ -16,7 +16,7 @@ def walk(f):
 
 .marches[].montant |= if type == "string" then tonumber else . end |
 .marches[].valeurGlobale |= if type == "string" then tonumber else . end |
-.marches[].dureeMois |= if type == "string" then tonumber | ceil(.) else ceil(.) end |
+.marches[].dureeMois |= if (type == "string" and length > 0) then tonumber | ceil(.) elif (type == "number") then ceil(.) else 1 end |
 .marches[].lieuExecution.code |= if type == "number" then tostring else . end |
 .marches[].lieuExecution.nom |= if type == "number" then tostring else . end |
 .marches[].id |= if type == "number" then tostring else . end |


### PR DESCRIPTION
Bonjour,

Suite au fix précédent (jq) quelques fichiers de marches-publics.info tombent en erreur sur la CI : 

```
Correction de aws-marchespublics-annee-2019.json...
jq: error (at ./original-data/aws-marchespublics-annee-2019.json:3654667): Expected JSON value (while parsing '')
Correction de aws-marchespublics-annee-2020.json...
jq: error (at ./original-data/aws-marchespublics-annee-2020.json:4097946): Expected JSON value (while parsing '')
Correction de aws-marchespublics-annee-2021.json...
jq: error (at ./original-data/aws-marchespublics-annee-2021.json:3569669): Expected JSON value (while parsing '')
```

Cela est dû à la propriété dureeMois qui est vide dans quelques rares cas. Exemple Marché ID 201933PA04 de aws-marchespublics-annee-2019.json : 

```
      "dureeMois": "",
``` 

Edit : j'oublie de préciser : je mets la valeur par défaut à 1 dans le cas où on n'arrive pas à détecter un nombre sur la propriété dureeMois. Valeur totalement arbitraire car je n'ai pas trouvé de "valeur par défaut" pour ce champ dans le reste du projet...